### PR TITLE
Dwta 204

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "postinstall": "npm run setup:husky",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
-    "format": "prettier --write 'test/**/*.js' '**/*.{js,md,json,config.js}'",
-    "format:check": "prettier --check 'test/**/*.js' '**/*.{js,md,json,config.js}'",
+    "format": "prettier --write \"test/**/*.js\" \"**/*.{js,md,json,config.js}\"",
+    "format:check": "prettier --check \"test/**/*.js\" \"**/*.{js,md,json,config.js}\"",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "git:pre-commit-hook": "npm run format:check && npm run lint",
@@ -25,6 +25,7 @@
     "test:uat": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern \"(WasteMovementExternalAPI|WasteMovementBackendAPI/BulkUpload|Authentication)\"",
     "test:zap-gate": "PROXY_MODE=off NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern zap-gate",
     "test:smoke": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern \"@smoke\"",
+    "test:prod-smoke": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern \"@prod-smoke\"",
     "test": "npm run test:${PROFILE:-uat}",
     "test-name-pattern": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern",
     "test-location-pattern": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern",

--- a/test/CONFIGURATION.md
+++ b/test/CONFIGURATION.md
@@ -13,6 +13,7 @@ This test suite requires certain environment variables to be set for authenticat
 
 - `ENVIRONMENT`: The environment name (defaults to 'test')
 - `RESULTS_OUTPUT_S3_PATH`: S3 path for publishing test results (used in CI/CD)
+- `API_CODE_IN_GIO_ORG_EXCLUDE_LIST`: A comma seperated list of API codes. These API codes will NOT send audit logs to S3, as they 'should' be excluded by the waste-backend service, which has the corresponding org ids for these API codes. When API_CODE_IN_GIO_ORG_EXCLUDE_LIST is set, the tests will exclusively use API codes from the list when creating/updating movements.
 
 ## Setting Up Environment Variables
 

--- a/test/specs/WasteMovementBackendAPI/RetrieveMovement/retrieve-movement.test.js
+++ b/test/specs/WasteMovementBackendAPI/RetrieveMovement/retrieve-movement.test.js
@@ -34,11 +34,18 @@ describe('Retrieve movement (Functionality only in Pre Prod)', () => {
       expect(qaRetrieveStatus).toBe(200)
       expect(qaMovements).toHaveLength(1)
       const movement = qaMovements[0]
+      expect(movement).toHaveProperty('wasteTrackingId')
       expect(movement.wasteTrackingId).toBe(wasteTrackingId)
+      expect(movement).toHaveProperty('revision')
       expect(movement.revision).toEqual(expect.any(Number))
-      expect(movement).toHaveProperty('orgId')
+      expect(movement).toHaveProperty(
+        'submittingOrganisation.defraCustomerOrganisationId'
+      )
+      expect(
+        movement.submittingOrganisation.defraCustomerOrganisationId
+      ).toEqual(expect.any(String))
+      expect(movement).toHaveProperty('traceId')
       expect(movement.traceId).toEqual(expect.any(String))
-      expect(movement.receipt.movement.apiCode).toBe(wasteReceiptData.apiCode)
     })
 
     it('should return both revisions when includeHistory is true after create and update @allure.label.tag:DWTA-45', async () => {

--- a/test/specs/WasteMovementExternalAPI/CreateWasteMovement/gio-org-exclude-list.test.js
+++ b/test/specs/WasteMovementExternalAPI/CreateWasteMovement/gio-org-exclude-list.test.js
@@ -3,7 +3,7 @@ import { generateBaseWasteReceiptData } from '../../../support/test-data-manager
 import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
 import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
 
-describe('GIO Org Exclude List', () => {
+describe('@prod-smoke - GIO Org Exclude List', () => {
   let wasteReceiptData
 
   beforeEach(async () => {
@@ -21,9 +21,6 @@ describe('GIO Org Exclude List', () => {
       'should successfully create a waste movement when the organisation is in the GIO org exclude list' +
         ' @allure.label.tag:DWTA-204',
       async () => {
-        wasteReceiptData.apiCode =
-          globalThis.testConfig.apiCodeInGioOrgExcludeList
-
         const response =
           await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
             wasteReceiptData

--- a/test/specs/WasteMovementExternalAPI/CreateWasteMovement/gio-org-exclude-list.test.js
+++ b/test/specs/WasteMovementExternalAPI/CreateWasteMovement/gio-org-exclude-list.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from '@jest/globals'
+import { generateBaseWasteReceiptData } from '../../../support/test-data-manager.js'
+import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
+import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
+
+describe('GIO Org Exclude List', () => {
+  let wasteReceiptData
+
+  beforeEach(async () => {
+    await addAllureLink('/DWTA-204', 'DWTA-204', 'jira')
+    wasteReceiptData = generateBaseWasteReceiptData()
+
+    await authenticateAndSetToken(
+      globalThis.testConfig.cognitoClientId,
+      globalThis.testConfig.cognitoClientSecret
+    )
+  })
+
+  describe('Successful Creation', () => {
+    it(
+      'should successfully create a waste movement when the organisation is in the GIO org exclude list' +
+        ' @allure.label.tag:DWTA-204',
+      async () => {
+        wasteReceiptData.apiCode =
+          globalThis.testConfig.apiCodeInGioOrgExcludeList
+
+        const response =
+          await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
+            wasteReceiptData
+          )
+
+        expect(response.statusCode).toBe(201)
+        expect(response.json).toEqual({
+          wasteTrackingId: expect.any(String)
+        })
+      }
+    )
+  })
+})

--- a/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/gio-org-exclude-list.test.js
+++ b/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/gio-org-exclude-list.test.js
@@ -3,7 +3,7 @@ import { generateBaseWasteReceiptData } from '../../../support/test-data-manager
 import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
 import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
 
-describe('GIO Org Exclude List', () => {
+describe('@prod-smoke - GIO Org Exclude List', () => {
   let wasteReceiptData
 
   beforeEach(async () => {
@@ -21,9 +21,6 @@ describe('GIO Org Exclude List', () => {
       'should successfully update a waste movement when the organisation is in the GIO org exclude list' +
         ' @allure.label.tag:DWTA-204',
       async () => {
-        wasteReceiptData.apiCode =
-          globalThis.testConfig.apiCodeInGioOrgExcludeList
-
         const createResponse =
           await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
             wasteReceiptData
@@ -33,7 +30,6 @@ describe('GIO Org Exclude List', () => {
         const wasteTrackingId = createResponse.json.wasteTrackingId
 
         const updatedData = generateBaseWasteReceiptData()
-        updatedData.apiCode = globalThis.testConfig.apiCodeInGioOrgExcludeList
         updatedData.wasteItems[0].disposalOrRecoveryCodes = [
           {
             code: 'D1',

--- a/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/gio-org-exclude-list.test.js
+++ b/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/gio-org-exclude-list.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from '@jest/globals'
+import { generateBaseWasteReceiptData } from '../../../support/test-data-manager.js'
+import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
+import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
+
+describe('GIO Org Exclude List', () => {
+  let wasteReceiptData
+
+  beforeEach(async () => {
+    await addAllureLink('/DWTA-204', 'DWTA-204', 'jira')
+    wasteReceiptData = generateBaseWasteReceiptData()
+
+    await authenticateAndSetToken(
+      globalThis.testConfig.cognitoClientId,
+      globalThis.testConfig.cognitoClientSecret
+    )
+  })
+
+  describe('Successful Updates', () => {
+    it(
+      'should successfully update a waste movement when the organisation is in the GIO org exclude list' +
+        ' @allure.label.tag:DWTA-204',
+      async () => {
+        wasteReceiptData.apiCode =
+          globalThis.testConfig.apiCodeInGioOrgExcludeList
+
+        const createResponse =
+          await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
+            wasteReceiptData
+          )
+        expect(createResponse.statusCode).toBe(201)
+
+        const wasteTrackingId = createResponse.json.wasteTrackingId
+
+        const updatedData = generateBaseWasteReceiptData()
+        updatedData.apiCode = globalThis.testConfig.apiCodeInGioOrgExcludeList
+        updatedData.wasteItems[0].disposalOrRecoveryCodes = [
+          {
+            code: 'D1',
+            weight: {
+              metric: 'Tonnes',
+              amount: 3.0,
+              isEstimate: false
+            }
+          }
+        ]
+
+        const updateResponse =
+          await globalThis.apis.wasteMovementExternalAPI.receiveMovementWithId(
+            wasteTrackingId,
+            updatedData
+          )
+
+        expect(updateResponse.statusCode).toBe(200)
+        expect(updateResponse.json).toEqual({})
+      }
+    )
+  })
+})

--- a/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/update-waste-movement.test.js
+++ b/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/update-waste-movement.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from '@jest/globals'
+import { randomUUID } from 'node:crypto'
 import { generateBaseWasteReceiptData } from '../../../support/test-data-manager.js'
 import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
 import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
@@ -54,8 +55,16 @@ describe('@smoke - Waste Movement Update', () => {
         ' @allure.label.tag:DWT-823',
       async () => {
         await addAllureLink('/DWT-823', 'DWT-823', 'jira')
-        // First create a movement
-        wasteReceiptData.apiCode = '75ff9140-8617-406e-9163-2ba4907e645b'
+
+        // This organisation will have multiple API codes
+        const orgWithMultipleApiCodes = randomUUID()
+        const orgApiCode1 =
+          await globalThis.apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
+            orgWithMultipleApiCodes
+          )
+        wasteReceiptData.apiCode = orgApiCode1.json.code
+        // wasteReceiptData.apiCode = '75ff9140-8617-406e-9163-2ba4907e645b'
+        // Create a movement for the org with the first API code
         const createResponse =
           await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
             wasteReceiptData
@@ -64,9 +73,15 @@ describe('@smoke - Waste Movement Update', () => {
 
         const wasteTrackingId = createResponse.json.wasteTrackingId
 
-        // Update the movement with different disposal codes
+        // Create a second API code for the same org
+        const orgApiCode2 =
+          await globalThis.apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
+            orgWithMultipleApiCodes
+          )
+        // Update the movement with a different API code from the same org
         const updatedData = generateBaseWasteReceiptData()
-        updatedData.apiCode = '94d744a5-e6d0-4c71-82c8-db52405cbba5'
+        updatedData.apiCode = orgApiCode2.json.code
+        //updatedData.apiCode = '94d744a5-e6d0-4c71-82c8-db52405cbba5'
 
         const updateResponse =
           await globalThis.apis.wasteMovementExternalAPI.receiveMovementWithId(

--- a/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/update-waste-movement.test.js
+++ b/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/update-waste-movement.test.js
@@ -81,7 +81,7 @@ describe('@smoke - Waste Movement Update', () => {
         // Update the movement with a different API code from the same org
         const updatedData = generateBaseWasteReceiptData()
         updatedData.apiCode = orgApiCode2.json.code
-        //updatedData.apiCode = '94d744a5-e6d0-4c71-82c8-db52405cbba5'
+        // updatedData.apiCode = '94d744a5-e6d0-4c71-82c8-db52405cbba5'
 
         const updateResponse =
           await globalThis.apis.wasteMovementExternalAPI.receiveMovementWithId(

--- a/test/support/README.md
+++ b/test/support/README.md
@@ -28,6 +28,8 @@ Generates a complete waste receipt data object with all required fields for the 
 - `acceptance`: Acceptance details
 - `receipt`: Receipt information with disposal/recovery codes
 
+> **Note (`apiCode`):** The value is sourced from `globalThis.generatedApiCode`, which global setup sets to either the `API_CODE_IN_GIO_ORG_EXCLUDE_LIST` environment variable or an API code auto-generated via `wasteOrganisationBackendAPI.createApiCodeForOrganisation` when that variable is unset.
+
 ### Example Usage
 
 ```javascript

--- a/test/support/jest/global-setup.js
+++ b/test/support/jest/global-setup.js
@@ -3,54 +3,68 @@ import { testConfig } from '../test-config.js'
 import { randomUUID } from 'crypto'
 
 /**
- * Runs once before all test workers when PROXY_MODE=zap.
- * Clears the ZAP session and disables selected passive scan rules for the Docker Compose harness.
+ * Runs once before all test workers.
+ * ZAP session setup only executes when PROXY_MODE=zap. Clears the ZAP session and disables selected passive scan rules for the Docker Compose harness.
  * @returns {Promise<void>}
  */
 export default async function globalSetup() {
+  globalThis.testConfig = testConfig
   const apis = ApiFactory.create()
-  if (globalThis.testConfig.apiCodeInGioOrgExcludeList === undefined) {
-    const createCodeResponse =
-      await apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
-        randomUUID()
-      )
-    expect(createCodeResponse.statusCode).toBe(200)
-    globalThis.generatedApiCode = createCodeResponse.json.code
-  } else {
-    globalThis.generatedApiCode =
-      globalThis.testConfig.apiCodeInGioOrgExcludeList
-  }
 
-  if (testConfig.proxyMode === 'zap') {
-    globalThis.testConfig = testConfig
-    const sessionResponse = await apis.zapApi.newSession()
-    if (
-      sessionResponse.statusCode !== 200 ||
-      sessionResponse.json?.Result !== 'OK'
-    ) {
-      await apis.close()
-      throw new Error(
-        `ZAP newSession failed with status ${sessionResponse.statusCode} and result ${sessionResponse.json?.Result}`
-      )
-    }
-
-    // Docker Compose CI uses HTTP + Basic auth on the internal network; disable in ZAP for this harness only.
-    const zapPassiveScanRulesToDisable = ['10105']
-
-    for (const pluginId of zapPassiveScanRulesToDisable) {
-      const thresholdResponse =
-        await apis.zapApi.setPassiveScannerAlertThreshold(pluginId, 'OFF')
-      if (
-        thresholdResponse.statusCode !== 200 ||
-        thresholdResponse.json?.Result !== 'OK'
-      ) {
-        await apis.close()
+  try {
+    if (testConfig.apiCodeInGioOrgExcludeList === undefined) {
+      const createCodeResponse =
+        await apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
+          randomUUID()
+        )
+      // TODO - Discuss with Lewis: globalSetup runs in a completely separate Node.js process before Jest initialises, so 'expect' is not available
+      if (createCodeResponse.statusCode !== 200) {
         throw new Error(
-          `ZAP setPassiveScannerAlertThreshold failed for plugin ${pluginId} ` +
-            `(status ${thresholdResponse.statusCode}, result ${thresholdResponse.json?.Result})`
+          `Failed to create organisation API code: status ${createCodeResponse.statusCode}`
         )
       }
+      // TODO - Discuss with Lewis: The workers cannot 'see' globalThis from this file, so we have to use process.env to share the generated API code.
+      // We can move this logic into the workers (setup.js) which will run before each test, but we will be creating new API codes via the organisation API for each test, which may be undesirable.
+      // For now, we will generate one API code for the entire test run and share it via an environment variable with the worker nodes.
+      process.env.GENERATED_API_CODE = createCodeResponse.json.code
+    } else {
+      const apiCodes = testConfig.apiCodeInGioOrgExcludeList
+        .split(',')
+        .map((code) => code.trim())
+        .filter(Boolean)
+      process.env.GENERATED_API_CODE =
+        apiCodes[Math.floor(Math.random() * apiCodes.length)] // get a random API code from the list
     }
+
+    if (testConfig.proxyMode === 'zap') {
+      const sessionResponse = await apis.zapApi.newSession()
+      if (
+        sessionResponse.statusCode !== 200 ||
+        sessionResponse.json?.Result !== 'OK'
+      ) {
+        throw new Error(
+          `ZAP newSession failed with status ${sessionResponse.statusCode} and result ${sessionResponse.json?.Result}`
+        )
+      }
+
+      // Docker Compose CI uses HTTP + Basic auth on the internal network; disable in ZAP for this harness only.
+      const zapPassiveScanRulesToDisable = ['10105']
+
+      for (const pluginId of zapPassiveScanRulesToDisable) {
+        const thresholdResponse =
+          await apis.zapApi.setPassiveScannerAlertThreshold(pluginId, 'OFF')
+        if (
+          thresholdResponse.statusCode !== 200 ||
+          thresholdResponse.json?.Result !== 'OK'
+        ) {
+          throw new Error(
+            `ZAP setPassiveScannerAlertThreshold failed for plugin ${pluginId} ` +
+              `(status ${thresholdResponse.statusCode}, result ${thresholdResponse.json?.Result})`
+          )
+        }
+      }
+    }
+  } finally {
+    await apis.close()
   }
-  await apis?.close()
 }

--- a/test/support/jest/global-setup.js
+++ b/test/support/jest/global-setup.js
@@ -1,5 +1,6 @@
 import { ApiFactory } from '../../apis/api-factory.js'
 import { testConfig } from '../test-config.js'
+import { randomUUID } from 'crypto'
 
 /**
  * Runs once before all test workers when PROXY_MODE=zap.
@@ -7,9 +8,21 @@ import { testConfig } from '../test-config.js'
  * @returns {Promise<void>}
  */
 export default async function globalSetup() {
+  const apis = ApiFactory.create()
+  if (globalThis.testConfig.apiCodeInGioOrgExcludeList === undefined) {
+    const createCodeResponse =
+      await apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
+        randomUUID()
+      )
+    expect(createCodeResponse.statusCode).toBe(200)
+    globalThis.generatedApiCode = createCodeResponse.json.code
+  } else {
+    globalThis.generatedApiCode =
+      globalThis.testConfig.apiCodeInGioOrgExcludeList
+  }
+
   if (testConfig.proxyMode === 'zap') {
     globalThis.testConfig = testConfig
-    const apis = ApiFactory.create()
     const sessionResponse = await apis.zapApi.newSession()
     if (
       sessionResponse.statusCode !== 200 ||
@@ -38,7 +51,6 @@ export default async function globalSetup() {
         )
       }
     }
-
-    await apis.close()
   }
+  await apis?.close()
 }

--- a/test/support/jest/setup.js
+++ b/test/support/jest/setup.js
@@ -3,6 +3,7 @@ import { testConfig } from '../../support/test-config.js'
 
 // Set testConfig globally at module load time (before tests are parsed).
 globalThis.testConfig = testConfig
+globalThis.generatedApiCode = process.env.GENERATED_API_CODE
 
 // Setup before each test
 beforeEach(async () => {

--- a/test/support/jest/setup.js
+++ b/test/support/jest/setup.js
@@ -1,9 +1,27 @@
 import { ApiFactory } from '../../apis/api-factory.js'
 import { testConfig } from '../../support/test-config.js'
-// Note: Global this is per worker
+import { randomUUID } from 'crypto'
 
 // Set testConfig globally at module load time (before tests are parsed).
 globalThis.testConfig = testConfig
+
+beforeAll(async () => {
+  globalThis.apis = ApiFactory.create()
+  if (globalThis.testConfig.apiCodeInGioOrgExcludeList === undefined) {
+    const createCodeResponse =
+      await globalThis.apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
+        randomUUID()
+      )
+    expect(createCodeResponse.statusCode).toBe(200)
+    globalThis.generatedApiCode = createCodeResponse.json.code
+  } else {
+    globalThis.generatedApiCode =
+      globalThis.testConfig.apiCodeInGioOrgExcludeList
+  }
+  if (globalThis.apis) {
+    await Promise.all(Object.values(globalThis.apis).map((api) => api.close()))
+  }
+})
 
 // Setup before each test
 beforeEach(async () => {
@@ -14,4 +32,13 @@ beforeEach(async () => {
 afterEach(async () => {
   await globalThis.apis?.close()
   delete globalThis.apis
+})
+
+// Global teardown - runs once after all tests
+afterAll(async () => {
+  delete globalThis.generatedApiCode
+  // Close API agents to clean up connections
+  if (globalThis.apis) {
+    await Promise.all(Object.values(globalThis.apis).map((api) => api.close()))
+  }
 })

--- a/test/support/jest/setup.js
+++ b/test/support/jest/setup.js
@@ -1,27 +1,8 @@
 import { ApiFactory } from '../../apis/api-factory.js'
 import { testConfig } from '../../support/test-config.js'
-import { randomUUID } from 'crypto'
 
 // Set testConfig globally at module load time (before tests are parsed).
 globalThis.testConfig = testConfig
-
-beforeAll(async () => {
-  globalThis.apis = ApiFactory.create()
-  if (globalThis.testConfig.apiCodeInGioOrgExcludeList === undefined) {
-    const createCodeResponse =
-      await globalThis.apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
-        randomUUID()
-      )
-    expect(createCodeResponse.statusCode).toBe(200)
-    globalThis.generatedApiCode = createCodeResponse.json.code
-  } else {
-    globalThis.generatedApiCode =
-      globalThis.testConfig.apiCodeInGioOrgExcludeList
-  }
-  if (globalThis.apis) {
-    await Promise.all(Object.values(globalThis.apis).map((api) => api.close()))
-  }
-})
 
 // Setup before each test
 beforeEach(async () => {
@@ -32,13 +13,4 @@ beforeEach(async () => {
 afterEach(async () => {
   await globalThis.apis?.close()
   delete globalThis.apis
-})
-
-// Global teardown - runs once after all tests
-afterAll(async () => {
-  delete globalThis.generatedApiCode
-  // Close API agents to clean up connections
-  if (globalThis.apis) {
-    await Promise.all(Object.values(globalThis.apis).map((api) => api.close()))
-  }
 })

--- a/test/support/test-config.js
+++ b/test/support/test-config.js
@@ -47,6 +47,17 @@ export class TestConfig {
     return process.env.COGNITO_OAUTH_BASE_URL
   }
 
+  /**
+   * Organisation API code for testing GIO org exclude behaviour in pre-prod environments.
+   * This shouldn't be used in the production smoke tests.
+   * @returns {string} The API code
+   */
+  get apiCodeInGioOrgExcludeList() {
+    return process.env.API_CODE_IN_GIO_ORG_EXCLUDE_LIST
+      ? process.env.API_CODE_IN_GIO_ORG_EXCLUDE_LIST
+      : undefined
+  }
+
   // Service auth password for the Waste Movement External API to connect to other services
   get serviceAuthPassword() {
     return process.env.SERVICE_AUTH_PASSWORD

--- a/test/support/test-data-manager.js
+++ b/test/support/test-data-manager.js
@@ -10,7 +10,7 @@
  * @returns {Object} Complete waste receipt data object
  */
 export const generateBaseWasteReceiptData = () => ({
-  apiCode: '1f83215e-4b90-4785-9ab2-2614839aa2e9',
+  apiCode: globalThis.generatedApiCode,
   dateTimeReceived: new Date().toISOString(),
   wasteItems: [
     {

--- a/test/types/globals.js
+++ b/test/types/globals.js
@@ -32,3 +32,9 @@ globalThis.testConfig = null
  * @type {Allure}
  */
 globalThis.allure = undefined
+
+/**
+ * API code generated in beforeEach when GIO org exclude list testing is enabled
+ * @type {string|undefined}
+ */
+globalThis.generatedApiCode = undefined


### PR DESCRIPTION
Title: DWTA-204: Add GIO org exclude list smoke tests and dynamic API code management

Summary
Introduces API_CODE_IN_GIO_ORG_EXCLUDE_LIST env var — when set, a random code from the list is used as the API code in the create/update waste movements payloads. API codes listed here should have corresponding organisation IDs in an exclusion list in the waste-backend service. These organisations will NOT send an audit log to S3. If API_CODE_IN_GIO_ORG_EXCLUDE_LIST is not set, the tests will generate an API code dynamically using the organisation backend service. Note: API_CODE_IN_GIO_ORG_EXCLUDE_LIST should always be set in prod via a secret in CDP. 

Adds a new 'test:prod-smoke' npm script to run smoke tests in prod. In prod, API_CODE_IN_GIO_ORG_EXCLUDE_LIST will include production organisation API codes, which will be used for running smoke tests after releases. These organisations will NOT send an audit log to S3, therefore not sending audit data to the GIO system. 

Refactors global setup to dynamically generate an API code at the start of each test run (via wasteOrganisationBackendAPI), instead of relying on a hardcoded API code

Updates the multi-API-code update test (DWT-823) to generate two real org API codes dynamically rather than using hardcoded UUIDs

Fixes Prettier glob patterns in package.json (single → double quotes for Windows compatibility. Should still work normally on MAC)