### PR TITLE
Add Ext-Test env config for Digital Waste Tracking Backend API

### DIFF
--- a/bruno/Digital-Waste-Tracking-Backend-API/environments/ext-test-environment.bru
+++ b/bruno/Digital-Waste-Tracking-Backend-API/environments/ext-test-environment.bru
@@ -1,0 +1,12 @@
+vars {
+  baseUrl: https://ephemeral-protected.api.ext-test.cdp-int.defra.cloud/waste-movement-backend
+  env: ext-test
+}
+vars:secret [
+  apiCode,
+  cdp-api-key,
+  SERVICE_AUTH_PASSWORD,
+  SERVICE_AUTH_PASSWORD_WASTE_ORGANISATION_BACKEND,
+  AUTH_PASSWORD_QA_NON_PROD,
+  AUTH_PASSWORD_PRODUCTION_APPROVAL_TESTS
+]


### PR DESCRIPTION
This change adds Ext-Test env config for the Digital Waste Tracking Backend API Collection.

The vars in this file are based on the Test config for this collection so includes the same config.