### PR TITLE
Skip global setup when running ZAP gate tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,10 @@
 export default {
   testEnvironment: 'allure-jest/node',
   setupFilesAfterEnv: ['<rootDir>/test/support/jest/setup.js'],
-  globalSetup: '<rootDir>/test/support/jest/global-setup.js',
+  globalSetup:
+    process.env.EXCLUDE_GLOBAL_SETUP === 'true'
+      ? undefined
+      : '<rootDir>/test/support/jest/global-setup.js',
   globalTeardown: '<rootDir>/test/support/jest/global-teardown.js',
   reporters: [
     'default',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "git:pre-commit-hook": "npm run format:check && npm run lint",
     "test:integration": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern \"^.*(WasteMovementExternalAPI|WasteMovementBackendAPI).*$\" --testNamePattern \"^(?!.*@Authentication)\"",
     "test:uat": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern \"(WasteMovementExternalAPI|WasteMovementBackendAPI/BulkUpload|Authentication)\"",
-    "test:zap-gate": "PROXY_MODE=off NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern zap-gate",
+    "test:zap-gate": "PROXY_MODE=off EXCLUDE_GLOBAL_SETUP=true NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern zap-gate",
     "test:smoke": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern \"@smoke\"",
     "test:prod-smoke": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern \"@prod-smoke\"",
     "test": "npm run test:${PROFILE:-uat}",


### PR DESCRIPTION
The ZAP gate test script sets EXCLUDE_GLOBAL_SETUP=true to bypass the Jest global setup step, which is unnecessary. The
jest.config.js respects this flag by conditionally omitting globalSetup.