### PR TITLE
Removed hard coded defra ID used in bulk upload payload - This is now…

### DIFF
--- a/test/CONFIGURATION.md
+++ b/test/CONFIGURATION.md
@@ -13,7 +13,19 @@ This test suite requires certain environment variables to be set for authenticat
 
 - `ENVIRONMENT`: The environment name (defaults to 'test')
 - `RESULTS_OUTPUT_S3_PATH`: S3 path for publishing test results (used in CI/CD)
-- `API_CODE_IN_GIO_ORG_EXCLUDE_LIST`: A comma seperated list of API codes. These API codes will NOT send audit logs to S3, as they 'should' be excluded by the waste-backend service, which has the corresponding org ids for these API codes. When API_CODE_IN_GIO_ORG_EXCLUDE_LIST is set, the tests will exclusively use API codes from the list when creating/updating movements.
+- `API_CODE_IN_GIO_ORG_EXCLUDE_LIST`: A comma-separated list of API codes for organisations excluded from GIO audit logging. These API codes will NOT send audit logs to S3, as they should be excluded by the waste-backend service, which has the corresponding org IDs for these API codes. Global setup behaviour:
+  - **Unset** — creates a new API code via `createApiCodeForOrganisation` for a random organisation ID
+  - **Set** — picks a random API code from the comma-separated list
+  - **Either way** — calls `getOrganisationByApiCode` to resolve `defraCustomerOrganisationId` for use in bulk upload test data
+
+### Runtime-Generated Variables (Read-Only)
+
+Global setup writes these into `process.env` before workers start. Do not set them in `env.sh`; worker processes read them via `test/support/jest/setup.js`.
+
+| Variable             | Set by            | Exposed in tests as           | Purpose                                                         |
+| -------------------- | ----------------- | ----------------------------- | --------------------------------------------------------------- |
+| `GENERATED_API_CODE` | `global-setup.js` | `globalThis.generatedApiCode` | API code for external API movement tests                        |
+| `GENERATED_DEFRA_ID` | `global-setup.js` | `globalThis.generatedDefraId` | `defraCustomerOrganisationId` for backend bulk upload test data |
 
 ## Setting Up Environment Variables
 

--- a/test/README.md
+++ b/test/README.md
@@ -177,6 +177,19 @@ const environment = globalThis.testConfig.environment
 
 The test suite validates that all required environment variables are present when tests start. If any required variables are missing, tests will fail with a clear error message.
 
+## Global Setup
+
+Before Jest workers start, `test/support/jest/global-setup.js` runs in a separate Node.js process and:
+
+1. Resolves an API code — creates one via `createApiCodeForOrganisation` when `API_CODE_IN_GIO_ORG_EXCLUDE_LIST` is unset, or picks a random code from the list when it is set
+2. Looks up the organisation via `getOrganisationByApiCode` and reads `defraCustomerOrganisationId`
+3. Sets `GENERATED_API_CODE` and `GENERATED_DEFRA_ID` on `process.env` for worker processes
+4. When `PROXY_MODE=zap`, initialises the ZAP session (see [ZAP security scan](#zap-security-scan-two-step))
+
+Worker processes read these values in `test/support/jest/setup.js` as `globalThis.generatedApiCode` and `globalThis.generatedDefraId`. See `CONFIGURATION.md` for required environment variables and runtime-generated variable details.
+
+Global setup is skipped when `EXCLUDE_GLOBAL_SETUP=true` (used by `test:zap-gate`). Tests that depend on `generatedApiCode` or `generatedDefraId` will fail without global setup.
+
 ## Environment Configuration
 
 Some tests require environment variables to be set. Before running tests, configure your environment:
@@ -217,6 +230,8 @@ Tests are organized into logical groups:
 - `npm test` - Run UAT profile tests (`test:uat` by default)
 - `npm run test:integration` - Integration API tests (excludes `@Authentication`)
 - `npm run test:uat` - UAT profile including bulk upload and authentication
+- `npm run test:smoke` - Tests tagged `@smoke`
+- `npm run test:prod-smoke` - Tests tagged `@prod-smoke` (A small subset of tests to run after production releases)
 - `npm run test:zap-gate` - ZAP gate only (`PROXY_MODE=off`; requires scan artefacts)
 - `jest` - Run Jest directly without report scripts
 - `jest --testPathPattern=test/specs/Authentication/` - Run specific test directories
@@ -237,7 +252,7 @@ OWASP ZAP passive scanning is intended for **Docker Compose CI** (internal HTTP 
 ### Flow
 
 1. **Scan** — set `PROXY_MODE=zap` and `HTTP_PROXY` to the ZAP proxy (e.g. in `env.sh`), then run integration tests:
-   - `test/support/jest/global-setup.js` — `newSession` and disable passive scan rules listed in `zapPassiveScanRulesToDisable`
+   - `test/support/jest/global-setup.js` — resolves API code and organisation ID, then `newSession` and disable passive scan rules listed in `zapPassiveScanRulesToDisable`
    - Tests execute through the proxy
    - `test/support/jest/global-teardown.js` — writes `zap-report/zap.json`, `zap.html`, and `alerts-summary.json`
 2. **Gate** — `PROXY_MODE=off`, `npm run test:zap-gate`:

--- a/test/specs/WasteMovementBackendAPI/BulkUpload/bulk-upload-update.test.js
+++ b/test/specs/WasteMovementBackendAPI/BulkUpload/bulk-upload-update.test.js
@@ -44,7 +44,7 @@ describe('Bulk Upload Update', () => {
       })
     })
 
-    it('should accept bulk update of two movements after create', async () => {
+    it('@prod-smoke should accept bulk update of two movements after create', async () => {
       const bulkUploadId = randomUUID()
 
       const createResponse =

--- a/test/specs/WasteMovementBackendAPI/BulkUpload/bulk-upload-update.test.js
+++ b/test/specs/WasteMovementBackendAPI/BulkUpload/bulk-upload-update.test.js
@@ -44,7 +44,7 @@ describe('Bulk Upload Update', () => {
       })
     })
 
-    it('@prod-smoke should accept bulk update of two movements after create', async () => {
+    it('should accept bulk update of two movements after create', async () => {
       const bulkUploadId = randomUUID()
 
       const createResponse =

--- a/test/specs/WasteMovementExternalAPI/CreateWasteMovement/gio-org-exclude-list.test.js
+++ b/test/specs/WasteMovementExternalAPI/CreateWasteMovement/gio-org-exclude-list.test.js
@@ -3,6 +3,8 @@ import { generateBaseWasteReceiptData } from '../../../support/test-data-manager
 import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
 import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
 
+// TODO - Discuss with Lewis: The create movement is already done in the corresponding
+// update 'gio-org-exclude-list'movement test. Can this test be removed?
 describe('@prod-smoke - GIO Org Exclude List', () => {
   let wasteReceiptData
 

--- a/test/specs/WasteMovementExternalAPI/ReferenceData/get-pop-names.test.js
+++ b/test/specs/WasteMovementExternalAPI/ReferenceData/get-pop-names.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from '@jest/globals'
 import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
 import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
 
-describe('@smoke - Retrieve Pop names', () => {
+describe('@prod-smoke @smoke - Retrieve Pop names', () => {
   beforeEach(async () => {
     await addAllureLink('/DWT-720', 'DWT-720', 'jira')
     await addAllureLink('/DWT-1288', 'DWT-1288', 'jira')

--- a/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/gio-org-exclude-list.test.js
+++ b/test/specs/WasteMovementExternalAPI/UpdateWasteMovement/gio-org-exclude-list.test.js
@@ -3,6 +3,7 @@ import { generateBaseWasteReceiptData } from '../../../support/test-data-manager
 import { authenticateAndSetToken } from '../../../support/helpers/auth.js'
 import { addAllureLink } from '~/test/support/helpers/allure-api-logger.js'
 
+// TODO - Discuss with Lewis: Why not tag a standard update movement test with @prod-smoke?
 describe('@prod-smoke - GIO Org Exclude List', () => {
   let wasteReceiptData
 

--- a/test/support/README.md
+++ b/test/support/README.md
@@ -28,7 +28,7 @@ Generates a complete waste receipt data object with all required fields for the 
 - `acceptance`: Acceptance details
 - `receipt`: Receipt information with disposal/recovery codes
 
-> **Note (`apiCode`):** The value is sourced from `globalThis.generatedApiCode`, which global setup sets to either the `API_CODE_IN_GIO_ORG_EXCLUDE_LIST` environment variable or an API code auto-generated via `wasteOrganisationBackendAPI.createApiCodeForOrganisation` when that variable is unset.
+> **Note (`apiCode`):** The value is sourced from `globalThis.generatedApiCode`, set once per test run in global setup. If `API_CODE_IN_GIO_ORG_EXCLUDE_LIST` is unset, setup creates a code via `createApiCodeForOrganisation`; otherwise it picks one from the list. Setup then calls `getOrganisationByApiCode` to resolve the defra organisation ID which is used by `generateBaseBulkUploadMovement()` when generating the bulk upload payloads.
 
 ### Example Usage
 

--- a/test/support/jest/global-setup.js
+++ b/test/support/jest/global-setup.js
@@ -3,6 +3,16 @@ import { testConfig } from '../test-config.js'
 import { randomUUID } from 'crypto'
 
 /**
+ * @param {{ statusCode: number }} response
+ * @param {string} message
+ */
+function assertOkResponse(response, message) {
+  if (response.statusCode !== 200) {
+    throw new Error(`${message}: status ${response.statusCode}`)
+  }
+}
+
+/**
  * Runs once before all test workers.
  * ZAP session setup only executes when PROXY_MODE=zap. Clears the ZAP session and disables selected passive scan rules for the Docker Compose harness.
  * @returns {Promise<void>}
@@ -12,29 +22,40 @@ export default async function globalSetup() {
   const apis = ApiFactory.create()
 
   try {
+    let apiCode
+
     if (testConfig.apiCodeInGioOrgExcludeList === undefined) {
       const createCodeResponse =
         await apis.wasteOrganisationBackendAPI.createApiCodeForOrganisation(
           randomUUID()
         )
       // TODO - Discuss with Lewis: globalSetup runs in a completely separate Node.js process before Jest initialises, so 'expect' is not available
-      if (createCodeResponse.statusCode !== 200) {
-        throw new Error(
-          `Failed to create organisation API code: status ${createCodeResponse.statusCode}`
-        )
-      }
+      assertOkResponse(
+        createCodeResponse,
+        'Failed to create organisation API code'
+      )
       // TODO - Discuss with Lewis: The workers cannot 'see' globalThis from this file, so we have to use process.env to share the generated API code.
       // We can move this logic into the workers (setup.js) which will run before each test, but we will be creating new API codes via the organisation API for each test, which may be undesirable.
       // For now, we will generate one API code for the entire test run and share it via an environment variable with the worker nodes.
-      process.env.GENERATED_API_CODE = createCodeResponse.json.code
+      apiCode = createCodeResponse.json.code
     } else {
       const apiCodes = testConfig.apiCodeInGioOrgExcludeList
         .split(',')
         .map((code) => code.trim())
         .filter(Boolean)
-      process.env.GENERATED_API_CODE =
-        apiCodes[Math.floor(Math.random() * apiCodes.length)] // get a random API code from the list
+      apiCode = apiCodes[Math.floor(Math.random() * apiCodes.length)]
     }
+
+    process.env.GENERATED_API_CODE = apiCode
+
+    const organisationResponse =
+      await apis.wasteOrganisationBackendAPI.getOrganisationByApiCode(apiCode)
+    assertOkResponse(
+      organisationResponse,
+      'Failed to get organisation by API code'
+    )
+    process.env.GENERATED_DEFRA_ID =
+      organisationResponse.json.defraCustomerOrganisationId
 
     if (testConfig.proxyMode === 'zap') {
       const sessionResponse = await apis.zapApi.newSession()

--- a/test/support/jest/setup.js
+++ b/test/support/jest/setup.js
@@ -4,6 +4,7 @@ import { testConfig } from '../../support/test-config.js'
 // Set testConfig globally at module load time (before tests are parsed).
 globalThis.testConfig = testConfig
 globalThis.generatedApiCode = process.env.GENERATED_API_CODE
+globalThis.generatedDefraId = process.env.GENERATED_DEFRA_ID
 
 // Setup before each test
 beforeEach(async () => {

--- a/test/support/test-data-manager.js
+++ b/test/support/test-data-manager.js
@@ -65,7 +65,7 @@ export const generateBaseWasteReceiptData = () => ({
 export const generateBaseBulkUploadMovement = () => ({
   submittingOrganisation: {
     // random organisation id from which we will need to replace when validation is implemented
-    defraCustomerOrganisationId: 'f3d1596d-bc77-427f-932c-4eeca7488749'
+    defraCustomerOrganisationId: globalThis.generatedDefraId
   },
   dateTimeReceived: new Date().toISOString(),
   wasteItems: [

--- a/test/support/test-data-manager.js
+++ b/test/support/test-data-manager.js
@@ -64,7 +64,7 @@ export const generateBaseWasteReceiptData = () => ({
  */
 export const generateBaseBulkUploadMovement = () => ({
   submittingOrganisation: {
-    // random organisation id from which we will need to replace when validation is implemented
+    // Defra org ID is determined during global-setup based on the API code being used
     defraCustomerOrganisationId: globalThis.generatedDefraId
   },
   dateTimeReceived: new Date().toISOString(),

--- a/test/types/globals.js
+++ b/test/types/globals.js
@@ -34,7 +34,13 @@ globalThis.testConfig = null
 globalThis.allure = undefined
 
 /**
- * API code generated in beforeEach when GIO org exclude list testing is enabled
+ * API code generated in global setup for the test run
  * @type {string|undefined}
  */
 globalThis.generatedApiCode = undefined
+
+/**
+ * Defra customer organisation ID resolved from the generated API code in global setup
+ * @type {string|undefined}
+ */
+globalThis.generatedDefraId = undefined


### PR DESCRIPTION
## Summary
- Resolve `defraCustomerOrganisationId` dynamically in global setup by looking up the organisation for the generated API code, removing the hardcoded UUID from bulk upload test data
- Expose `GENERATED_DEFRA_ID` to worker processes as `globalThis.generatedDefraId` for use in `generateBaseBulkUploadMovement()`
- Extend production smoke coverage with `@prod-smoke` on bulk upload update (create + update flow) and POP names reference data; document global setup behaviour and runtime-generated variables
