### PR TITLE
DWTA-276 - Pops and hazardous flag validation

### DIFF
--- a/test/specs/WasteMovementExternalAPI/CreateWasteMovement/hazardous-properties-indicator.test.js
+++ b/test/specs/WasteMovementExternalAPI/CreateWasteMovement/hazardous-properties-indicator.test.js
@@ -157,6 +157,34 @@ describe('Hazardous Properties Indicator Validation', () => {
       })
     })
 
+    it(
+      'should reject waste receipt when containsHazardous is true and hazardous is missing' +
+        ' @allure.label.tag:DWTA-276',
+      async () => {
+        await addAllureLink('/DWTA-276', 'DWTA-276', 'jira')
+        wasteReceiptData.wasteItems[0].containsHazardous = true
+        delete wasteReceiptData.wasteItems[0].hazardous
+
+        const response =
+          await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
+            wasteReceiptData
+          )
+
+        expect(response.statusCode).toBe(400)
+        expect(response.json).toEqual({
+          validation: {
+            errors: [
+              {
+                key: 'wasteItems.0.hazardous',
+                errorType: 'NotProvided',
+                message: '"wasteItems[0].hazardous" is required'
+              }
+            ]
+          }
+        })
+      }
+    )
+
     it('should reject waste receipt when hazardous indicator is invalid', async () => {
       wasteReceiptData.wasteItems[0].containsHazardous = 'invalid'
       wasteReceiptData.wasteItems[0].hazardous = {}

--- a/test/specs/WasteMovementExternalAPI/CreateWasteMovement/pops-indicator.test.js
+++ b/test/specs/WasteMovementExternalAPI/CreateWasteMovement/pops-indicator.test.js
@@ -120,5 +120,33 @@ describe('POPs Indicator Validation', () => {
         }
       })
     })
+
+    it(
+      'should reject waste when containsPops is true and pops is missing' +
+        ' @allure.label.tag:DWTA-276',
+      async () => {
+        await addAllureLink('/DWTA-276', 'DWTA-276', 'jira')
+        wasteReceiptData.wasteItems[0].containsPops = true
+        delete wasteReceiptData.wasteItems[0].pops
+
+        const response =
+          await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
+            wasteReceiptData
+          )
+
+        expect(response.statusCode).toBe(400)
+        expect(response.json).toEqual({
+          validation: {
+            errors: [
+              {
+                key: 'wasteItems.0.pops',
+                errorType: 'NotProvided',
+                message: '"wasteItems[0].pops" is required'
+              }
+            ]
+          }
+        })
+      }
+    )
   })
 })


### PR DESCRIPTION
Two new tests. Ensure 'hazardous' JSON object must exist when 'containsHazardous = true'. Similar test for pops. 