### PR TITLE
DWTA-293 Update PAT Response

### DIFF
--- a/test/apis/wasteMovementBackendApi.js
+++ b/test/apis/wasteMovementBackendApi.js
@@ -25,7 +25,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
       Authorization: `Basic ${base64Credentials}`,
       'Content-Type': 'application/json',
       'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-dwt-client-id': globalThis.testConfig.cognitoClientId
     }
     if (globalThis.testConfig.cdpDevApiKey != null) {
       requestHeaders['x-api-key'] = globalThis.testConfig.cdpDevApiKey
@@ -51,7 +51,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
       Authorization: `Basic ${base64Credentials}`,
       'Content-Type': 'application/json',
       'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-dwt-client-id': globalThis.testConfig.cognitoClientId
     }
     if (globalThis.testConfig.cdpDevApiKey != null) {
       requestHeaders['x-api-key'] = globalThis.testConfig.cdpDevApiKey
@@ -77,7 +77,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
       Authorization: `Basic ${base64Credentials}`,
       'Content-Type': 'application/json',
       'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-dwt-client-id': globalThis.testConfig.cognitoClientId
     }
 
     // Only add the CDP Dev API key if it is set. This is only need for running locally.
@@ -111,7 +111,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
       Authorization: `Basic ${base64Credentials}`,
       'Content-Type': 'application/json',
       'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-dwt-client-id': globalThis.testConfig.cognitoClientId
     }
     if (globalThis.testConfig.cdpDevApiKey != null) {
       requestHeaders['x-api-key'] = globalThis.testConfig.cdpDevApiKey
@@ -166,7 +166,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
     const requestHeaders = {
       Authorization: `Basic ${base64Credentials}`,
       'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-dwt-client-id': globalThis.testConfig.cognitoClientId
     }
     if (globalThis.testConfig.cdpDevApiKey != null) {
       requestHeaders['x-api-key'] = globalThis.testConfig.cdpDevApiKey

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-b01-broker-or-dealer-involvement.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-b01-broker-or-dealer-involvement.test.js
@@ -38,14 +38,17 @@ describe('Production Approval Test B01 - Broker or Dealer Involvement', () => {
           [{ scenarioId: 'B01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'B01',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'B01',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -66,14 +69,17 @@ describe('Production Approval Test B01 - Broker or Dealer Involvement', () => {
           [{ scenarioId: 'B01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'B01',
-          wasteTrackingId,
-          status: 'Fail',
-          message: 'No broker or dealer involvement in the movement'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'B01',
+            wasteTrackingId,
+            status: 'Fail',
+            message: 'No broker or dealer involvement in the movement'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-c02-no-carrier-registration-with-reason.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-c02-no-carrier-registration-with-reason.test.js
@@ -32,14 +32,17 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
           [{ scenarioId: 'C02', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'C02',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'C02',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -58,15 +61,18 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
           [{ scenarioId: 'C02', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'C02',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'C02',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
+          }
+        ]
+      })
     })
 
     it('should fail when a waste movement is created with a blank reason for no registration number and a receive warning', async () => {
@@ -86,15 +92,18 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
           [{ scenarioId: 'C02', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'C02',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'C02',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
+          }
+        ]
+      })
     })
 
     it('should fail when a waste movement is created with a null reason for no registration number and a receive warning', async () => {
@@ -114,15 +123,18 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
           [{ scenarioId: 'C02', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'C02',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'C02',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h01-multiple-hazardous-components.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h01-multiple-hazardous-components.test.js
@@ -49,14 +49,17 @@ describe('Production Approval Test H01 - Multiple Hazardous Components', () => {
           [{ scenarioId: 'H01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'H01',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'H01',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -78,15 +81,18 @@ describe('Production Approval Test H01 - Multiple Hazardous Components', () => {
           [{ scenarioId: 'H01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'H01',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected one or more waste items to have multiple hazardous components'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'H01',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected one or more waste items to have multiple hazardous components'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h03-no-consignment-code-with-reason.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h03-no-consignment-code-with-reason.test.js
@@ -47,14 +47,17 @@ describe('Production Approval Test H03 - No Consignment Code With Reason', () =>
           [{ scenarioId: 'H03', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'H03',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'H03',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -88,14 +91,17 @@ describe('Production Approval Test H03 - No Consignment Code With Reason', () =>
           [{ scenarioId: 'H03', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'H03',
-          wasteTrackingId,
-          status: 'Fail',
-          message: 'Expected reasonForNoConsignmentCode to be given for H03'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'H03',
+            wasteTrackingId,
+            status: 'Fail',
+            message: 'Expected reasonForNoConsignmentCode to be given for H03'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-p01-pops-components.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-p01-pops-components.test.js
@@ -48,14 +48,17 @@ describe('Production Approval Test P01 - POPs Components', () => {
           [{ scenarioId: 'P01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'P01',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'P01',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -77,15 +80,18 @@ describe('Production Approval Test P01 - POPs Components', () => {
           [{ scenarioId: 'P01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'P01',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected one or more waste items to have multiple POPs components'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'P01',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected one or more waste items to have multiple POPs components'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r01-single-waste-item.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r01-single-waste-item.test.js
@@ -37,14 +37,17 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
           [{ scenarioId: 'R01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R01',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R01',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -65,14 +68,17 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
           [{ scenarioId: 'R01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R01',
-          wasteTrackingId,
-          status: 'Fail',
-          message: 'No disposal or recovery code provided'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R01',
+            wasteTrackingId,
+            status: 'Fail',
+            message: 'No disposal or recovery code provided'
+          }
+        ]
+      })
     })
 
     it('should fail when a waste movement is supplied with multiple waste items', async () => {
@@ -92,14 +98,17 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
           [{ scenarioId: 'R01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R01',
-          wasteTrackingId,
-          status: 'Fail',
-          message: 'Multiple waste items provided'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R01',
+            wasteTrackingId,
+            status: 'Fail',
+            message: 'Multiple waste items provided'
+          }
+        ]
+      })
     })
 
     it('should fail when a waste movement is supplied with POPs components on the waste item', async () => {
@@ -127,14 +136,17 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
           [{ scenarioId: 'R01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R01',
-          wasteTrackingId,
-          status: 'Fail',
-          message: expect.stringMatching(/POPs components provided/i)
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R01',
+            wasteTrackingId,
+            status: 'Fail',
+            message: expect.stringMatching(/POPs components provided/i)
+          }
+        ]
+      })
     })
 
     it('should fail when a waste movement is supplied with a hazardous waste item', async () => {
@@ -157,14 +169,17 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
           [{ scenarioId: 'R01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R01',
-          wasteTrackingId,
-          status: 'Fail',
-          message: expect.stringMatching(/hazardous waste items provided/i)
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R01',
+            wasteTrackingId,
+            status: 'Fail',
+            message: expect.stringMatching(/hazardous waste items provided/i)
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r02-multiple-waste-items.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r02-multiple-waste-items.test.js
@@ -32,14 +32,17 @@ describe('Production Approval Test R02 - Multiple Waste Items', () => {
           [{ scenarioId: 'R02', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R02',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R02',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -58,14 +61,17 @@ describe('Production Approval Test R02 - Multiple Waste Items', () => {
           [{ scenarioId: 'R02', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R02',
-          wasteTrackingId,
-          status: 'Fail',
-          message: 'Expected more than 1 waste item for R02, found 1'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R02',
+            wasteTrackingId,
+            status: 'Fail',
+            message: 'Expected more than 1 waste item for R02, found 1'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r03-road-transport.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r03-road-transport.test.js
@@ -32,14 +32,17 @@ describe('Production Approval Test R03 - Road Transport', () => {
           [{ scenarioId: 'R03', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R03',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R03',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -61,15 +64,18 @@ describe('Production Approval Test R03 - Road Transport', () => {
           [{ scenarioId: 'R03', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R03',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected carrier.meansOfTransport to be "Road" for R03, found "Other"'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R03',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected carrier.meansOfTransport to be "Road" for R03, found "Other"'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r04-no-disposal-or-recovery-codes.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r04-no-disposal-or-recovery-codes.test.js
@@ -31,14 +31,17 @@ describe('Production Approval Test R04 - No Disposal or Recovery Codes', () => {
           [{ scenarioId: 'R04', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R04',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R04',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -57,15 +60,18 @@ describe('Production Approval Test R04 - No Disposal or Recovery Codes', () => {
           [{ scenarioId: 'R04', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R04',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected no disposal or recovery codes for R04, found codes on waste item(s) at index 0'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R04',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected no disposal or recovery codes for R04, found codes on waste item(s) at index 0'
+          }
+        ]
+      })
     })
 
     it('should fail when disposal or recovery codes are only on the second waste item', async () => {
@@ -87,15 +93,18 @@ describe('Production Approval Test R04 - No Disposal or Recovery Codes', () => {
           [{ scenarioId: 'R04', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R04',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected no disposal or recovery codes for R04, found codes on waste item(s) at index 1'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R04',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected no disposal or recovery codes for R04, found codes on waste item(s) at index 1'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r05-multiple-disposal-or-recovery-codes.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r05-multiple-disposal-or-recovery-codes.test.js
@@ -48,14 +48,17 @@ describe('Production Approval Test R05 - Multiple Disposal or Recovery Codes', (
           [{ scenarioId: 'R05', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R05',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R05',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
 
     it('should pass when multiple disposal or recovery codes are only on the second waste item', async () => {
@@ -94,14 +97,17 @@ describe('Production Approval Test R05 - Multiple Disposal or Recovery Codes', (
           [{ scenarioId: 'R05', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R05',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R05',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -120,15 +126,18 @@ describe('Production Approval Test R05 - Multiple Disposal or Recovery Codes', (
           [{ scenarioId: 'R05', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R05',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected at least one waste item to have multiple disposal or recovery codes for R05'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R05',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected at least one waste item to have multiple disposal or recovery codes for R05'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r07-dual-ewc-codes.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r07-dual-ewc-codes.test.js
@@ -31,14 +31,17 @@ describe('Production Approval Test R07 - Dual EWC Codes', () => {
           [{ scenarioId: 'R07', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R07',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R07',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -57,15 +60,18 @@ describe('Production Approval Test R07 - Dual EWC Codes', () => {
           [{ scenarioId: 'R07', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'R07',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected at least one waste item to have at least 2 EWC codes for R07'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'R07',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected at least one waste item to have at least 2 EWC codes for R07'
+          }
+        ]
+      })
     })
   })
 })

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-x01-hazardous-and-pops-components.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-x01-hazardous-and-pops-components.test.js
@@ -54,14 +54,17 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
           [{ scenarioId: 'X01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'X01',
-          wasteTrackingId,
-          status: 'Pass',
-          message: ''
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'X01',
+            wasteTrackingId,
+            status: 'Pass',
+            message: ''
+          }
+        ]
+      })
     })
   })
 
@@ -93,15 +96,18 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
           [{ scenarioId: 'X01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'X01',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected one or more waste items to have POPs and Hazardous components'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'X01',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected one or more waste items to have POPs and Hazardous components'
+          }
+        ]
+      })
     })
 
     it('should fail when a waste item is supplied with hazardous components but no POPs components', async () => {
@@ -134,15 +140,18 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
           [{ scenarioId: 'X01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'X01',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected one or more waste items to have POPs and Hazardous components'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'X01',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected one or more waste items to have POPs and Hazardous components'
+          }
+        ]
+      })
     })
 
     it('should fail when hazardous and POPs components are on different waste items', async () => {
@@ -190,15 +199,18 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
           [{ scenarioId: 'X01', wasteTrackingId }]
         )
       expect(patResponse.statusCode).toBe(200)
-      expect(patResponse.json).toEqual([
-        {
-          scenarioId: 'X01',
-          wasteTrackingId,
-          status: 'Fail',
-          message:
-            'Expected one or more waste items to have POPs and Hazardous components'
-        }
-      ])
+      expect(patResponse.json).toEqual({
+        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        results: [
+          {
+            scenarioId: 'X01',
+            wasteTrackingId,
+            status: 'Fail',
+            message:
+              'Expected one or more waste items to have POPs and Hazardous components'
+          }
+        ]
+      })
     })
   })
 })


### PR DESCRIPTION
We've updated the PAT endpoint response to return an object with a new `submissionId` property and a `results` property containing the results array, rather than just returning the results array.

This change updates that in the UAT tests.

Also updated the `x-dwt-client-id` header to pass through the actual client id value generated in the tests, rather than a random UUID.