### PR TITLE
DWTA-294: Skip TLS verification for proxied HTTPS calls only

### DIFF
--- a/test/apis/base-api.js
+++ b/test/apis/base-api.js
@@ -47,7 +47,12 @@ export class BaseAPI {
     if (globalThis.testConfig?.httpProxy && this.useProxyWhenAvailable) {
       this.agent = new ProxyAgent({
         uri: globalThis.testConfig.httpProxy,
-        ...baseOptions
+        ...baseOptions,
+        // ZAP MITMs HTTPS and presents its own Root CA. Accept that only on
+        // proxied calls (security-scan harness), not on direct Agent traffic.
+        requestTls: {
+          rejectUnauthorized: false
+        }
       })
       this.usingProxy = true
     } else {


### PR DESCRIPTION
Trying to fix the '**_Error: self-signed certificate in certificate chain_**' in the PR integration tests. i think turning the TLS verification off in ZAP might fix it. 