### PR TITLE
Dwta 293 check pat submissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:uat": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern \"(WasteMovementExternalAPI|WasteMovementBackendAPI/BulkUpload|Authentication)\"",
     "test:zap-gate": "PROXY_MODE=off EXCLUDE_GLOBAL_SETUP=true NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern zap-gate",
     "test:smoke": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern \"@smoke\"",
-    "test:prod-smoke": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern \"@prod-smoke\"",
+    "test:prod-smoke": "REDACT_SENSITIVE_ALLURE_HEADERS=true NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern \"@prod-smoke\"",
     "test": "npm run test:${PROFILE:-uat}",
     "test-name-pattern": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testNamePattern",
     "test-location-pattern": "NODE_OPTIONS='--experimental-vm-modules --no-warnings --dns-result-order=ipv6first --no-network-family-autoselection' jest --testPathPattern",

--- a/test/apis/wasteMovementBackendApi.js
+++ b/test/apis/wasteMovementBackendApi.js
@@ -24,8 +24,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
     const requestHeaders = {
       Authorization: `Basic ${base64Credentials}`,
       'Content-Type': 'application/json',
-      'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-cdp-request-id': randomUUID()
     }
     if (globalThis.testConfig.cdpDevApiKey != null) {
       requestHeaders['x-api-key'] = globalThis.testConfig.cdpDevApiKey
@@ -50,8 +49,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
     const requestHeaders = {
       Authorization: `Basic ${base64Credentials}`,
       'Content-Type': 'application/json',
-      'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-cdp-request-id': randomUUID()
     }
     if (globalThis.testConfig.cdpDevApiKey != null) {
       requestHeaders['x-api-key'] = globalThis.testConfig.cdpDevApiKey
@@ -76,8 +74,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
     const requestHeaders = {
       Authorization: `Basic ${base64Credentials}`,
       'Content-Type': 'application/json',
-      'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-cdp-request-id': randomUUID()
     }
 
     // Only add the CDP Dev API key if it is set. This is only need for running locally.
@@ -165,8 +162,7 @@ export class WasteMovementBackendAPI extends BaseAPI {
     const endpoint = `/qa-non-prod/movements?${qs}`
     const requestHeaders = {
       Authorization: `Basic ${base64Credentials}`,
-      'x-cdp-request-id': randomUUID(),
-      'x-dwt-client-id': randomUUID()
+      'x-cdp-request-id': randomUUID()
     }
     if (globalThis.testConfig.cdpDevApiKey != null) {
       requestHeaders['x-api-key'] = globalThis.testConfig.cdpDevApiKey

--- a/test/specs/WasteMovementBackendAPI/BulkUpload/bulk-upload-update.test.js
+++ b/test/specs/WasteMovementBackendAPI/BulkUpload/bulk-upload-update.test.js
@@ -44,7 +44,7 @@ describe('Bulk Upload Update', () => {
       })
     })
 
-    it('should accept bulk update of two movements after create', async () => {
+    it('@prod-smoke should accept bulk update of two movements after create', async () => {
       const bulkUploadId = randomUUID()
 
       const createResponse =

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-b01-broker-or-dealer-involvement.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-b01-broker-or-dealer-involvement.test.js
@@ -8,6 +8,7 @@ describe('Production Approval Test B01 - Broker or Dealer Involvement', () => {
 
   beforeEach(async () => {
     await addAllureLink('/DWTA-168', 'DWTA-168', 'jira')
+    await addAllureLink('/DWTA-293', 'DWTA-293', 'jira')
     wasteReceiptData = generateBaseWasteReceiptData()
     await authenticateAndSetToken(
       globalThis.testConfig.cognitoClientId,
@@ -39,7 +40,7 @@ describe('Production Approval Test B01 - Broker or Dealer Involvement', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'B01',
@@ -70,7 +71,7 @@ describe('Production Approval Test B01 - Broker or Dealer Involvement', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'B01',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-c02-no-carrier-registration-with-reason.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-c02-no-carrier-registration-with-reason.test.js
@@ -33,7 +33,7 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'C02',
@@ -62,7 +62,7 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'C02',
@@ -93,7 +93,7 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'C02',
@@ -124,7 +124,7 @@ describe('Production Approval Test C02 - No Carrier Registration Number and Reas
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'C02',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h01-multiple-hazardous-components.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h01-multiple-hazardous-components.test.js
@@ -50,7 +50,7 @@ describe('Production Approval Test H01 - Multiple Hazardous Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'H01',
@@ -82,7 +82,7 @@ describe('Production Approval Test H01 - Multiple Hazardous Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'H01',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h03-no-consignment-code-with-reason.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-h03-no-consignment-code-with-reason.test.js
@@ -48,7 +48,7 @@ describe('Production Approval Test H03 - No Consignment Code With Reason', () =>
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'H03',
@@ -92,7 +92,7 @@ describe('Production Approval Test H03 - No Consignment Code With Reason', () =>
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'H03',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-p01-pops-components.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-p01-pops-components.test.js
@@ -49,7 +49,7 @@ describe('Production Approval Test P01 - POPs Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'P01',
@@ -81,7 +81,7 @@ describe('Production Approval Test P01 - POPs Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'P01',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r01-single-waste-item.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r01-single-waste-item.test.js
@@ -38,7 +38,7 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R01',
@@ -69,7 +69,7 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R01',
@@ -99,7 +99,7 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R01',
@@ -137,7 +137,7 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R01',
@@ -170,7 +170,7 @@ describe('Production Approval Test R01 - Single Waste Item', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R01',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r02-multiple-waste-items.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r02-multiple-waste-items.test.js
@@ -33,7 +33,7 @@ describe('Production Approval Test R02 - Multiple Waste Items', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R02',
@@ -62,7 +62,7 @@ describe('Production Approval Test R02 - Multiple Waste Items', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R02',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r03-road-transport.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r03-road-transport.test.js
@@ -33,7 +33,7 @@ describe('Production Approval Test R03 - Road Transport', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R03',
@@ -65,7 +65,7 @@ describe('Production Approval Test R03 - Road Transport', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R03',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r04-no-disposal-or-recovery-codes.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r04-no-disposal-or-recovery-codes.test.js
@@ -32,7 +32,7 @@ describe('Production Approval Test R04 - No Disposal or Recovery Codes', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R04',
@@ -61,7 +61,7 @@ describe('Production Approval Test R04 - No Disposal or Recovery Codes', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R04',
@@ -94,7 +94,7 @@ describe('Production Approval Test R04 - No Disposal or Recovery Codes', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R04',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r05-multiple-disposal-or-recovery-codes.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r05-multiple-disposal-or-recovery-codes.test.js
@@ -49,7 +49,7 @@ describe('Production Approval Test R05 - Multiple Disposal or Recovery Codes', (
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R05',
@@ -98,7 +98,7 @@ describe('Production Approval Test R05 - Multiple Disposal or Recovery Codes', (
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R05',
@@ -127,7 +127,7 @@ describe('Production Approval Test R05 - Multiple Disposal or Recovery Codes', (
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R05',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r07-dual-ewc-codes.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-r07-dual-ewc-codes.test.js
@@ -32,7 +32,7 @@ describe('Production Approval Test R07 - Dual EWC Codes', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R07',
@@ -61,7 +61,7 @@ describe('Production Approval Test R07 - Dual EWC Codes', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'R07',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-x01-hazardous-and-pops-components.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/ScenarioTests/pat-x01-hazardous-and-pops-components.test.js
@@ -55,7 +55,7 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'X01',
@@ -97,7 +97,7 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'X01',
@@ -141,7 +141,7 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'X01',
@@ -200,7 +200,7 @@ describe('Production Approval Test X01 - Hazardous and POPs Components', () => {
         )
       expect(patResponse.statusCode).toBe(200)
       expect(patResponse.json).toEqual({
-        submissionId: expect.any(String), // Only testing for a string value for now as we'll need a GET PAT endpoint to fetch submissionId
+        submissionId: expect.any(String),
         results: [
           {
             scenarioId: 'X01',

--- a/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/SubmissionTests/pat-all-scenarios-assessment.test.js
+++ b/test/specs/WasteMovementBackendAPI/ProductionApprovalTests/SubmissionTests/pat-all-scenarios-assessment.test.js
@@ -21,6 +21,7 @@ async function createMovementAndGetWasteTrackingId(wasteReceiptData) {
 describe('Production Approval Tests All Automated Scenarios', () => {
   beforeEach(async () => {
     await addAllureLink('/DWTA-177', 'DWTA-177', 'jira')
+    await addAllureLink('/DWTA-293', 'DWTA-293', 'jira')
     await authenticateAndSetToken(
       globalThis.testConfig.cognitoClientId,
       globalThis.testConfig.cognitoClientSecret

--- a/test/specs/WasteMovementExternalAPI/CreateWasteMovement/receiver-authorisation-number.test.js
+++ b/test/specs/WasteMovementExternalAPI/CreateWasteMovement/receiver-authorisation-number.test.js
@@ -106,6 +106,21 @@ describe('Receiver Authorisation Number Validation', () => {
         expect(response.json).toHaveProperty('wasteTrackingId')
       }
     )
+
+    it(
+      'should accept waste movement when receiver authorisation is a 5 digit mobile deployment permit number' +
+        ' @allure.label.tag:DWTA-290',
+      async () => {
+        await addAllureLink('/DWTA-290', 'DWTA-290', 'jira')
+        wasteReceiptData.receiver.authorisationNumber = 'EPR/AB1234CD/D12345'
+        const response =
+          await globalThis.apis.wasteMovementExternalAPI.receiveMovement(
+            wasteReceiptData
+          )
+        expect(response.statusCode).toBe(201)
+        expect(response.json).toHaveProperty('wasteTrackingId')
+      }
+    )
   })
 
   describe('Invalid Receiver Authorisation Number Scenarios', () => {

--- a/test/support/helpers/allure-api-logger.js
+++ b/test/support/helpers/allure-api-logger.js
@@ -4,6 +4,91 @@
  * Provides Allure reporting functionality for API requests and responses
  */
 
+const REDACTED = '[REDACTED]'
+
+/**
+ * Whether Allure attachments should redact sensitive values (prod-smoke runs).
+ * @returns {boolean}
+ */
+function shouldRedactSensitiveAllureData() {
+  return process.env.REDACT_SENSITIVE_ALLURE_HEADERS === 'true'
+}
+
+/**
+ * Whether a header name should be redacted in Allure attachments.
+ * @param {string} headerName - Header name
+ * @returns {boolean}
+ */
+function isSensitiveHeaderName(headerName) {
+  const lowerName = headerName.toLowerCase()
+  return lowerName.includes('authorization') || lowerName === 'x-dwt-client-id'
+}
+
+/**
+ * Return a copy of headers with sensitive values redacted for Allure.
+ * Does not mutate the original headers object.
+ * @param {Object} headers - Request or response headers
+ * @returns {Object}
+ */
+function sanitizeHeadersForAllure(headers) {
+  if (!shouldRedactSensitiveAllureData()) {
+    return headers
+  }
+
+  const sanitized = {}
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    sanitized[key] = isSensitiveHeaderName(key) ? REDACTED : value
+  }
+  return sanitized
+}
+
+/**
+ * Recursively redact access_token properties on a cloned value
+ * (e.g. Cognito OAuth response bodies).
+ * @param {any} value - JSON-like value
+ * @returns {any}
+ */
+function redactAccessTokenDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactAccessTokenDeep(item))
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const sanitized = {}
+    for (const [key, nestedValue] of Object.entries(value)) {
+      sanitized[key] =
+        key.toLowerCase() === 'access_token'
+          ? REDACTED
+          : redactAccessTokenDeep(nestedValue)
+    }
+    return sanitized
+  }
+
+  return value
+}
+
+/**
+ * Return a copy of a body with access_token redacted for Allure.
+ * Does not mutate the original body.
+ * @param {string|Object|null} body - Request or response body
+ * @returns {string|Object|null}
+ */
+function sanitizeBodyForAllure(body) {
+  if (!shouldRedactSensitiveAllureData() || body == null) {
+    return body
+  }
+
+  if (typeof body === 'string') {
+    try {
+      return redactAccessTokenDeep(JSON.parse(body))
+    } catch {
+      return body
+    }
+  }
+
+  return redactAccessTokenDeep(body)
+}
+
 /**
  * Log API request details to Allure report
  * @param {string} method - HTTP method (GET, POST, PUT, etc.)
@@ -25,11 +110,13 @@ export async function logAllureRequest(
     await globalThis.allure.step(
       `${method} Request to ${endpoint}`,
       async () => {
+        const sanitizedHeaders = sanitizeHeadersForAllure(headers)
+
         // Attach request details to Allure report
         globalThis.allure.attachment('Request URL', url, 'text/plain')
         globalThis.allure.attachment(
           'Request Headers',
-          JSON.stringify(headers, null, 2),
+          JSON.stringify(sanitizedHeaders, null, 2),
           'application/json'
         )
         if (usingProxy) {
@@ -43,9 +130,10 @@ export async function logAllureRequest(
           try {
             // Try to parse as JSON for better formatting
             const jsonData = typeof data === 'string' ? JSON.parse(data) : data
+            const sanitizedBody = sanitizeBodyForAllure(jsonData)
             globalThis.allure.attachment(
               'Request Body',
-              JSON.stringify(jsonData, null, 2),
+              JSON.stringify(sanitizedBody, null, 2),
               'application/json'
             )
           } catch {
@@ -77,6 +165,9 @@ export async function logAllureResponse(
     await globalThis.allure.step(
       `${method} Response from ${endpoint}`,
       async () => {
+        const sanitizedHeaders = sanitizeHeadersForAllure(headers)
+        const sanitizedBody = sanitizeBodyForAllure(body)
+
         globalThis.allure.attachment(
           'Response Status',
           `${statusCode}`,
@@ -84,7 +175,7 @@ export async function logAllureResponse(
         )
         globalThis.allure.attachment(
           'Response Headers',
-          JSON.stringify(headers, null, 2),
+          JSON.stringify(sanitizedHeaders, null, 2),
           'application/json'
         )
         globalThis.allure.attachment(
@@ -92,10 +183,10 @@ export async function logAllureResponse(
           `Response received with content-type: ${headers['content-type'] || 'unknown'}`,
           'text/plain'
         )
-        if (body) {
+        if (sanitizedBody) {
           globalThis.allure.attachment(
             'Response Body',
-            JSON.stringify(body, null, 2),
+            JSON.stringify(sanitizedBody, null, 2),
             'application/json'
           )
         }


### PR DESCRIPTION
- New test for DWTA-293: New 5 digit receiver authroisation number for mobile deployment permit numbers
- Redact sensitive info. from allure report in prod only. i.e. REDACT authorisation & x-client id header and cognito access tokens. 
- Remove redundant 'x-client'-id' headers from any backend calls that aren't for production approval tests
- Remove repetitive comments from PAT assertion tests