### PR TITLE
Global setup organisation ID bug fix

### DIFF
--- a/test/support/jest/global-setup.js
+++ b/test/support/jest/global-setup.js
@@ -23,10 +23,11 @@ export default async function globalSetup() {
 
   try {
     let apiCode
-    const organisationId = randomUUID()
+    let organisationId
 
     if (testConfig.apiCodeInGioOrgExcludeList === undefined) {
       // Create a new organisation and get the API code
+      organisationId = randomUUID()
       const organisationResponse =
         await apis.wasteOrganisationBackendAPI.createOrUpdateOrganisation(
           randomUUID(),


### PR DESCRIPTION
Small bug fix with generating the org id when the API exlusion list exists